### PR TITLE
Add partial matching in descriptive fields

### DIFF
--- a/lib/dataset.rb
+++ b/lib/dataset.rb
@@ -4,8 +4,10 @@ require 'json'
 # This class serves as a base class for all other data sets
 class Dataset
   @search_fields = []
+  @descriptive_fields = []
   class << self
     attr_accessor :search_fields
+    attr_accessor :descriptive_fields
   end
 
   attr_reader :list
@@ -24,11 +26,20 @@ class Dataset
   def search(field, value)
     result = []
     @list.each do |item|
-      if item[field].is_a?(Array) && item[field].include?(value)
-        result.push(item)
-      elsif item[field].to_s == value
-        result.push(item)
-      end
+      ###########
+      # This is a complex condition
+      # In the first part, if the search field is an array, we check if the value is included
+      # in the array. This is applicable to multivalued fileds like tags.
+      #
+      # The second condition is for descriptive fields where we want to do partial match,
+      # like names, description, etc. The condition  checks if the value is included in the field.
+      #
+      # The third condition does a simple value match
+      next unless item[field].is_a?(Array) && item[field].include?(value) ||
+                  self.class.descriptive_fields.include?(field) && item[field] && item[field].include?(value) ||
+                  item[field].to_s == value
+
+      result.push(item)
     end
     result
   end

--- a/lib/organizations.rb
+++ b/lib/organizations.rb
@@ -6,6 +6,9 @@ class Organizations < Dataset
   @search_fields = %w[
     _id url external_id name domain_names created_at details shared_tickets tags
   ]
+
+  @descriptive_fields = %w[name details]
+
   class << self
     attr_accessor :search_fields
   end

--- a/lib/tickets.rb
+++ b/lib/tickets.rb
@@ -7,6 +7,9 @@ class Tickets < Dataset
     _id url external_id created_at type subject description priority status recipient
     submitter_id assignee_id organization_id tags has_incidents due_at via requester_id
   ]
+
+  @descriptive_fields = %w[subject description]
+
   class << self
     attr_accessor :search_fields
   end

--- a/lib/users.rb
+++ b/lib/users.rb
@@ -7,6 +7,8 @@ class Users < Dataset
     _id url external_id name alias created_at active verified shared locale timezone
     last_login_at email phone signature organization_id tags suspended role
   ]
+
+  @descriptive_fields = %w[name alias signature]
   class << self
     attr_accessor :search_fields
   end

--- a/spec/lib/dataset_spec.rb
+++ b/spec/lib/dataset_spec.rb
@@ -4,7 +4,7 @@ describe 'Dataset' do
   before do
     @filename = 'dataset.json'
     @list =
-      '[{"_id": 1,"url": "fake_url1","name": "name1","type": "common_type","tags": ["tag1","tag2"]},'\
+      '[{"_id": 1,"url": "fake_url1","name": "first1 last1","type": "common_type","tags": ["tag1","tag2"]},'\
       '{"_id": 2,"organization_name": "fake_url2","name": "name2","type": "common_type","tags": ["tag3"]}]'
   end
   context '#initialize with file name' do
@@ -32,7 +32,7 @@ describe 'Dataset' do
   context '#initialize with list' do
     before do
       @list = [
-        { '_id' => 1, 'name' => 'name1' },
+        { '_id' => 1, 'name' => 'first1 last1' },
         { '_id' => 2, 'name' => 'name2' }
       ]
     end
@@ -54,7 +54,7 @@ describe 'Dataset' do
       result = @data.search('_id', '1')
       expect(result.size).to be(1)
       expect(result[0]['_id']).to eq(1)
-      expect(result[0]['name']).to eq('name1')
+      expect(result[0]['name']).to eq('first1 last1')
     end
 
     it 'returns multiple matches' do
@@ -69,7 +69,15 @@ describe 'Dataset' do
       result = @data.search('tags', 'tag1')
       expect(result.size).to be(1)
       expect(result[0]['_id']).to eq(1)
-      expect(result[0]['name']).to eq('name1')
+      expect(result[0]['name']).to eq('first1 last1')
+    end
+
+    it 'should search through descriptive fields' do
+      Dataset.descriptive_fields = ['name']
+      result = @data.search('name', 'first1')
+      expect(result.size).to be(1)
+      expect(result[0]['_id']).to eq(1)
+      expect(result[0]['name']).to eq('first1 last1')
     end
   end
 
@@ -80,7 +88,7 @@ describe 'Dataset' do
       @output = "--------------------------------------------------------------\n"\
       "_id                       1\n"\
       "url                       fake_url1\n"\
-      "name                      name1\n"\
+      "name                      first1 last1\n"\
       "type                      common_type\n"\
       "tags                      [\"tag1\", \"tag2\"]\n"\
       "--------------------------------------------------------------\n"\

--- a/spec/lib/organization_spec.rb
+++ b/spec/lib/organization_spec.rb
@@ -10,4 +10,12 @@ describe 'Organizations' do
                ])
     end
   end
+
+  context '#descriptive fields' do
+    it 'returns descriptive fields' do
+      descriptive_fields = Organizations.descriptive_fields
+      expect(descriptive_fields)
+        .to eq(%w[name details])
+    end
+  end
 end

--- a/spec/lib/ticket_spec.rb
+++ b/spec/lib/ticket_spec.rb
@@ -11,4 +11,12 @@ describe 'Organizations' do
                ])
     end
   end
+
+  context '#descriptive fields' do
+    it 'returns descriptive fields' do
+      descriptive_fields = Tickets.descriptive_fields
+      expect(descriptive_fields)
+        .to eq(%w[subject description])
+    end
+  end
 end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -11,4 +11,12 @@ describe 'Users' do
                ])
     end
   end
+
+  context '#descriptive fields' do
+    it 'returns descriptive fields' do
+      descriptive_fields = Users.descriptive_fields
+      expect(descriptive_fields)
+        .to eq(%w[name alias signature])
+    end
+  end
 end


### PR DESCRIPTION
For fields like description, subject, etc. you don't expect to search
for the whole description. You instead want partial matches on the text